### PR TITLE
Fix naming typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+input.conf
+output.conf

--- a/.gitignore.conf
+++ b/.gitignore.conf
@@ -1,2 +1,0 @@
-input.conf
-output.conf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # secure-logstash-pipeline
+
+## Input and Output ##
+
+This pipeline does not provide inputs or outputs so you can configure whatever you need. Files named `input.conf` and `output.conf` will not interfere with updates via git, so name your files accordingly.
+
+Here are examples how your files could look if you want to use a local Redis instance.
+
+```
+input {
+  redis {
+    host => localhost
+    key => "secure"
+    data_type => list
+  }
+}
+
+output {
+  redis {
+    key => "forwarder"
+    data_type => list
+    host => localhost
+  }
+}
+``'

--- a/input.conf
+++ b/input.conf
@@ -1,7 +1,0 @@
-input {
-  redis {
-    host => localhost
-    key => "secure"
-    data_type => list
-  }
-}

--- a/output.conf
+++ b/output.conf
@@ -1,7 +1,0 @@
-output {
-  redis {
-    key => "forwarder"
-    data_type => list
-    host => localhost
-  }
-}


### PR DESCRIPTION
The file `.gitignore` mustn't have a `conf` in it's name. Otherwise it's ignored.