### PR TITLE
Fix _grokparsefaillure typo in tag_on_failure

### DIFF
--- a/filter-ssh.conf
+++ b/filter-ssh.conf
@@ -3,7 +3,7 @@ filter {
       grok {
         match => ["message", "%{WORD:[ssh][auth][result]} %{WORD:[ssh][auth][method]} for (invalid user )?%{USERNAME:[user][name]} from %{IPORHOST:[client][address]} port %{NUMBER:[client][port]} %{WORD:[ssh][protocol]}(: %{GREEDYDATA:[ssh][signature]})?"]
         id => "ssh_login"
-        tag_on_failure => ["_grokparsefaillure","ssh_login_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","ssh_login_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_accepted_connection"
         }
@@ -17,7 +17,7 @@ filter {
       grok {
         match => ["message","%{DATA:[ssh][auth][result]} user %{USERNAME:[user][name]} from %{IPORHOST:[client][address]}"]
         id => "ssh_login_suspection"
-        tag_on_failure => ["_grokparsefaillure","ssh_login_suspection_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","ssh_login_suspection_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_suspicious_connection"
         }
@@ -26,7 +26,7 @@ filter {
       grok {
         match => ["message","pam_unix\(%{DATA:[session][type]}\:session\)\: session %{DATA:[ssh][session][status]} for user %{USERNAME:[user][name]}( by (.*)?\(uid\=%{NUMBER:[uid]}\))?"]
         id => "pam_unix_session"
-        tag_on_failure => ["_grokparsefaillure","pam_unix_session_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","pam_unix_session_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_session_status"
         }
@@ -35,7 +35,7 @@ filter {
       grok {
         match => ["message","Did not receive identification string from %{IPORHOST:[client][ip]} port %{NUMBER:[client][port]}"]
         id => "ssh_noidentstring"
-        tag_on_failure => ["_grokparsefaillure","ssh_noidentstring_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","ssh_noidentstring_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_noidentstring"
         }
@@ -44,7 +44,7 @@ filter {
       grok {
         match => ["message","%{DATA:[ssh][session][status]} from( user %{USERNAME:[user][name]})? %{IPORHOST:[client][ip]} port %{BASE10NUM:[client][port]}(disconnected by user)?"]
         id => "ssh_disconnected"
-        tag_on_failure => ["_grokparsefaillure","ssh_disconnected_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","ssh_disconnected_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_session_status"
         } 
@@ -54,7 +54,7 @@ filter {
       grok {
         match => ["message","Connection %{DATA:[ssh][session][status]} by %{IPORHOST:[client][ip]} port %{BASE10NUM:[client][port]}"]
         id => "ssh_closed"
-        tag_on_failure => ["_grokparsefaillure","ssh_connection_closed_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","ssh_connection_closed_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_session_status"
         }
@@ -63,7 +63,7 @@ filter {
       grok {
         match => ["message","error: %{DATA:[ssh][session_error]}: %{GREEDYDATA:[ssh][error_message]}"]
         id => "ssh_error"
-        tag_on_failure => ["_grokparsefaillure","ssh_error_grok_failed"]
+        tag_on_failure => ["_grokparsefailure","ssh_error_grok_failed"]
         add_field => {
           "[ssh][eventtype]" => "ssh_error"
         } 


### PR DESCRIPTION
The doubled l meant these grok failures never showed up under the standard _grokparsefailure tag, so generic parse-failure views missed them.